### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   deploy:
     runs-on: self-hosted


### PR DESCRIPTION
Potential fix for [https://github.com/SEIU/ContractBot/security/code-scanning/1](https://github.com/SEIU/ContractBot/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root level of the workflow to explicitly define the minimal permissions required. Based on the workflow's operations, it does not appear to require any write permissions or access to GitHub features like issues, pull requests, or deployments. Therefore, we will set `contents: read` as the minimal permission. This ensures that the workflow adheres to the principle of least privilege while still functioning correctly.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
