### PR TITLE
VirtualEnv fails to activate

### DIFF
--- a/inference.sh
+++ b/inference.sh
@@ -50,5 +50,5 @@ else
 fi
 echo "Starting Inference Watcher"
 export TOKENIZERS_PARALLELISM=true
-source .venv/bin/activate
+source /venv/bin/activate
 nohup engine/watch 2>>$INFERENCE_LOG &


### PR DESCRIPTION
error messages:
inference.sh: line 53: .venv/bin/activate: No such file or directory
removing period resolves the problem on MacOS